### PR TITLE
fixed unnecessary return functions in RF and Quartets

### DIFF
--- a/distmetric/Quartets.py
+++ b/distmetric/Quartets.py
@@ -13,51 +13,51 @@ import os
 from .Sample import Sample, Generator
 
 
-class Quartets():
+class Quartets:
     """
     Class object to calculate phylogenetic tree distances with the quartet method
     """
+
     def __init__(self, trees, sampmethod, consensustree=None):
         # store inputs
-        self.trees = toytree.mtree(trees) 
+        self.trees = toytree.mtree(trees)
         # get consensus tree (if given the use user's consenus tree, or else, get consensus tree from trees provided in user input)
         self.consensustree = consensustree
         if self.consensustree == None:
             self.consensustree = self.trees.get_consensus_tree()
         # append consensus tree as last in tree list
         self.trees.treelist.append(self.consensustree)
-        
+
         self.treelist = self.trees.treelist
         self.sampmethod = sampmethod
-        
+
         # store output
         self.getquartetsout = {}
         self.samporder = []
-        self.output = pd.DataFrame(columns = ['trees', 'Quartet_intersection'])
-        
-        
+        self.output = pd.DataFrame(columns=["trees", "Quartet_intersection"])
+
     def get_quartets(self):
         """
         Find all possible quartets for each phylogenetic tree
         from user input and store in self.getquartetsout dictionary
         with key as tree #/consensus and value as quartet set.
-        """       
+        """
         # iterate over each tree in input
         for idx in range(len(self.trees)):
             ttre = self.treelist[idx]
-            
+
             # store all quartets in this SET
             qset = set([])
-    
+
             # get a SET with all tips in the tree
             fullset = set(ttre.get_tip_labels())
-    
+
             # get a SET of the descendants from each internal node
-            for node in ttre.idx_dict.values():   
+            for node in ttre.idx_dict.values():
 
                 # skip leaf nodes
                 if not node.is_leaf():
-            
+
                     children = set(node.get_leaf_names())
                     prod = itertools.product(
                         itertools.combinations(children, 2),
@@ -74,55 +74,64 @@ class Quartets():
                     sorted_set.add(tup)
                 else:
                     tup = tuple(sorted(qs[:2]) + sorted(qs[2:]))
-                    sorted_set.add(tup)            
-            
+                    sorted_set.add(tup)
+
             # if last tree, this means this is the quartet set for the consensus tree
-            if idx == len(self.trees)-1:
-                self.getquartetsout['consensus'] = sorted_set
+            if idx == len(self.trees) - 1:
+                self.getquartetsout["consensus"] = sorted_set
             # if not, treat quartet set as set for a normal tree that will soon be used for comparisons
             else:
                 self.getquartetsout[idx] = sorted_set
-        return self.getquartetsout    
+        # return self.getquartetsout, these returns are not used anyway
 
-        
     def compare_quartets(self):
         """
         Compare two sets of quartets generated from each pair of
         phylogenetic trees based on pairwise or random sampling order.
-        Return data frame with tree # and quartet metric. 
+        Return data frame with tree # and quartet metric.
         """
         # follow sampling order if user wants to calculate distances in pairwise/random fashion
         if self.sampmethod == "pairwise" or self.sampmethod == "random":
             # generate sampling order depending on pairwise or random user input
             # define max length as self.trees - 1 because last tree in list is consensus tree
-            length = len(self.trees)-1
+            length = len(self.trees) - 1
             samporder = Sample(length, self.sampmethod)
             self.samporder = samporder.sampling()
-        
+
             # iterate over each pair of trees depending on sampling order
-            for idx in range(len(self.trees)-2):             
+            for idx in range(len(self.trees) - 2):
                 q0 = self.getquartetsout[self.samporder[idx]]
-                q1 = self.getquartetsout[self.samporder[idx+1]]
-        
+                q1 = self.getquartetsout[self.samporder[idx + 1]]
+
                 # diffs = q0.symmetric_difference(q1)
                 # len(diffs)
-            
-                self.output = self.output.append({'trees' : str(self.samporder[idx])+ ", " + str(self.samporder[idx+1]), 
-                                                  'Quartet_intersection' : len(q0.intersection(q1)) / len(q0)},
-                                                 ignore_index = True)
+
+                self.output = self.output.append(
+                    {
+                        "trees": str(self.samporder[idx])
+                        + ", "
+                        + str(self.samporder[idx + 1]),
+                        "Quartet_intersection": len(q0.intersection(q1)) / len(q0),
+                    },
+                    ignore_index=True,
+                )
         # compares each tree with consensus
         else:
-            consensus = self.getquartetsout['consensus']
-            for idx in range(len(self.trees)-1):
+            consensus = self.getquartetsout["consensus"]
+            for idx in range(len(self.trees) - 1):
                 q0 = self.getquartetsout[idx]
-                self.output = self.output.append({'trees' : str(idx) + ", consensus", 
-                                                  'Quartet_intersection' : len(q0.intersection(consensus)) / len(consensus)},
-                                                 ignore_index = True)
-        #pd.set_option("display.max_rows", None, "display.max_columns", None)
+                self.output = self.output.append(
+                    {
+                        "trees": str(idx) + ", consensus",
+                        "Quartet_intersection": len(q0.intersection(consensus))
+                        / len(consensus),
+                    },
+                    ignore_index=True,
+                )
+        # pd.set_option("display.max_rows", None, "display.max_columns", None)
         # return data frame as output
-        return self.output        
-        
-        
+        # return self.output, these returns are not used anyway
+
     def run(self):
         """
         Define run function

--- a/distmetric/RF.py
+++ b/distmetric/RF.py
@@ -14,10 +14,11 @@ import os
 from .Sample import Sample, Generator
 
 
-class RF():
+class RF:
     """
     Class object to calculate phylogenetic tree distances with the quartet method
     """
+
     def __init__(self, trees, sampmethod, consensustree=None):
         # store inputs
         self.trees = toytree.mtree(trees)
@@ -27,58 +28,63 @@ class RF():
         # store output
         self.getrfout = {}
         self.samporder = []
-        self.output = pd.DataFrame(columns = ['trees', 'RF'])
-        
+        self.output = pd.DataFrame(columns=["trees", "RF"])
+
         self.consensustree = consensustree
         if self.consensustree == None:
             self.consensustree = self.trees.get_consensus_tree()
-    
-    
+
     def get_rf(self):
         """
         Function to get RFs depending on user input (pairwise/random sampling of trees
         vs. compare all trees with consensus tree)
-        Returns result in a dictionary, with key as tree # and value as RF value. 
+        Returns result in a dictionary, with key as tree # and value as RF value.
         """
         if self.sampmethod == "pairwise" or self.sampmethod == "random":
             samporder = Sample(len(self.trees), self.sampmethod)
             self.samporder = samporder.sampling()
 
-            for idx in range(len(self.trees)-1):
+            for idx in range(len(self.trees) - 1):
                 ttre1 = self.treelist[(self.samporder[idx])]
-                ttre2 = self.treelist[(self.samporder[idx+1])]
+                ttre2 = self.treelist[(self.samporder[idx + 1])]
 
                 rf = ttre1.treenode.robinson_foulds(ttre2.treenode)[0]
                 max_rf = ttre1.treenode.robinson_foulds(ttre2.treenode)[1]
-                final_rf = rf/max_rf
+                final_rf = rf / max_rf
 
-                self.getrfout[str(self.samporder[idx]) + ", " + str(self.samporder[idx+1])] = final_rf
-        
-        else:   #self.sampmethod == "consensus":
+                self.getrfout[
+                    str(self.samporder[idx]) + ", " + str(self.samporder[idx + 1])
+                ] = final_rf
+
+        else:  # self.sampmethod == "consensus":
             for idx in range(len(self.trees)):
                 ttre1 = self.treelist[idx]
-                rf = ttre1.treenode.robinson_foulds(self.consensustree.treenode, unrooted_trees=True)[0]
-                max_rf = ttre1.treenode.robinson_foulds(self.consensustree.treenode, unrooted_trees=True)[1]
-                final_rf = rf/max_rf
-                
+                rf = ttre1.treenode.robinson_foulds(
+                    self.consensustree.treenode, unrooted_trees=True
+                )[0]
+                max_rf = ttre1.treenode.robinson_foulds(
+                    self.consensustree.treenode, unrooted_trees=True
+                )[1]
+                final_rf = rf / max_rf
+
                 self.getrfout[str(idx) + ", consensus"] = final_rf
-        
-        return self.getrfout 
-    
-    
+
+        # return self.getrfout
+
     def compare_rf(self):
         """
         Function to compile tree # and associated RFs into a final data frame as output
         """
         for idx in self.getrfout:
-            self.output = self.output.append({'trees' : idx, 
-                                              'RF' : self.getrfout[idx]},
-                                              ignore_index = True)
-        return self.output
-    
+            self.output = self.output.append(
+                {"trees": idx, "RF": self.getrfout[idx]}, ignore_index=True
+            )
+        # return self.output, I would rather put the return line at the end of the `run` function
+
     def run(self):
         """
         Define run function
         """
         self.get_rf()
         self.compare_rf()
+        return self.output


### PR DESCRIPTION
In the defined functions of the class objects, there are several `return`s , which were not put in use. In the `Quartets.py` I simply removed the `return`  since you are using self.output to display your result, so your demo will still work. While in the `RF.py` I moved the `return self.output` to the `run` function so `obj.run()` will be your output. If you prefer to use `RF.output` as your output you can simply delete the `return` function that I added in the `run` function 